### PR TITLE
Fix permissions for installing rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           at: ./
       - run:
           name: Install rsync
-          command: apt install rsync
+          command: sudo apt install rsync
       - run:
           name: Upload to mipixel.com
           command: rsync -av ./_site mipixel@mipixel.com:~/public_html/  --delete --exclude '.htaccess' --exclude '.well-known'


### PR DESCRIPTION
sudo required to install rsync as the image is not being run as root